### PR TITLE
Only prefix the themosis framework plugin with `themosis-`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,9 @@
     },
     "extra":{
         "installer-paths":{
-            "htdocs/content/plugins/themosis-{$name}/": ["type:wordpress-plugin"],
-            "htdocs/content/themes/themosis-{$name}/": ["type:wordpress-theme"]
+            "htdocs/content/plugins/themosis-{$name}/": ["themosis/framework"],
+            "htdocs/content/themes/themosis-{$name}/": ["type:wordpress-theme"],
+			"htdocs/content/plugins/{$name}/": ["type:wordpress-plugin"]
         },
         "webroot-dir": "htdocs/cms",
     	"webroot-package": "wordpress/wordpress"


### PR DESCRIPTION
so other plugins installed via composer will not receive the prefix

Resolves #19 
