### PR TITLE
No need to prefix the themosis theme as we recommend to rename anyway

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     },
     "extra":{
         "installer-paths":{
-            "htdocs/content/plugins/themosis-{$name}/": ["type:wordpress-plugin"]
+            "htdocs/content/plugins/themosis-{$name}/": ["type:wordpress-plugin"],
+			"htdocs/content/themes/{$name}/": ["type:wordpress-theme"]
         },
         "webroot-dir": "htdocs/cms",
     	"webroot-package": "wordpress/wordpress"


### PR DESCRIPTION
This also means that any other themes installed via composer will not get incorrectly prefixed with `themosis-`

Resolves #20 
