### PR TITLE
Allow pattern in environnements

### DIFF
--- a/library/Thms/Config/Environment.php
+++ b/library/Thms/Config/Environment.php
@@ -52,7 +52,9 @@ class Environment
 
 		foreach ($this->locations as $location => $name)
 		{
-			if ($hostname === $name)
+			$pattern = ($name !== "/") ? str_replace('*', '(.*)', $name) . '\z' : '^/$';;
+
+			if ((bool) preg_match('#' . $pattern . '#', $hostname))
 			{
 				return $location;
 			}


### PR DESCRIPTION
Particularly useful for load balanced servers

Example : 

```
<?php

/*----------------------------------------------------*/
// Define your environments
/*----------------------------------------------------*/

return array(
    'local'             => '*.themosis.dev',
    'production'        => '*.themosis.com'
);
```
