### PR TITLE
Allowing arrays for names' location

### DIFF
--- a/library/Thms/Config/Environment.php
+++ b/library/Thms/Config/Environment.php
@@ -52,8 +52,8 @@ class Environment
 
 		foreach ($this->locations as $location => $name)
 		{
-			if ($hostname === $name)
-			{
+			$name = is_array( $name ) ? $name : [ $name ];
+			if (in_array( $hostname, $name )) {
 				return $location;
 			}
 		}


### PR DESCRIPTION
Sometimes the hostname just changes… Would be nice if we could set an array, like the old laravel 4.2 days.
E.g.:
```
'local'         => ['IGNISCODE.local','IGNISCODE.Home', 'IGNISCODE.lan'],
OR
'local'         => 'IGNISCODE.local',
```