### PR TITLE
added wpackagist as https

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"repositories":[
 		{
 			"type": "composer",
-			"url": "http://wpackagist.org"
+			"url": "https://wpackagist.org"
 		}
 	],
 	"autoload": {


### PR DESCRIPTION
as composer does not allow for insecure http connections by default, wpackgist.org has to be added as `https`, otherwise the installation fails with an exception:

```
[Composer\Downloader\TransportException]
  Your configuration does not allow connections to http://wpackagist.org/packages.json. See https://getcomposer.org/doc/06-config.md#secure-http for details.
```

fixes #99 