### PR TITLE
Adds alternative env file default loading

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+APP_ENV = local
+DB_NAME = "database-name"
+DB_USER = "database-user"
+DB_PASSWORD = "database-password"
+DB_HOST = "localhost"
+WP_HOME = "http://domain.tld"
+WP_SITEURL = "http://domain.tld/cms"

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,4 @@ cs_fixer*
 ### Environment Credentials
 .env
 .env.*
-!.env.local
+!.env.sample

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -5,7 +5,7 @@ $rootPath = dirname(__DIR__);
 /*----------------------------------------------------*/
 // Composer autoload
 /*----------------------------------------------------*/
-if (file_exists($autoload = $rootPath.DS.'vendor'.DS.'autoload.php')) {
+if (!file_exists($autoload = $rootPath.DS.'vendor'.DS.'autoload.php')) {
     die("Couldn't load the Composer autoload file.");
 }
 require_once $autoload;
@@ -38,7 +38,7 @@ try {
     $env->load();
     $env->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'WP_HOME', 'WP_SITEURL']);
 } catch (\Exception $e) {
-    die("Error in autoload.php around line 29: " . $e->getMessage());
+    die("Error in autoload.php around line 36: " . $e->getMessage());
 }
 
 /*

--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -1,59 +1,71 @@
 <?php
 
-/*----------------------------------------------------*/
-// Paths
-/*----------------------------------------------------*/
 $rootPath = dirname(__DIR__);
-$webrootPath = $rootPath.DS.'htdocs';
 
 /*----------------------------------------------------*/
 // Composer autoload
 /*----------------------------------------------------*/
 if (file_exists($autoload = $rootPath.DS.'vendor'.DS.'autoload.php')) {
-    require_once $autoload;
+    die("Couldn't load the Composer autoload file.");
 }
+require_once $autoload;
 
 /*----------------------------------------------------*/
 // Environment configuration
 /*----------------------------------------------------*/
+
 /*
- * Locations
+ * Checks if the environment.php file
+ * 1) exists, 2) isn't false, 3) isn't empty, 4) isn't default
+ * If the test fails then .env is used, otherwise .env.local.php, etc.
  */
-if (file_exists($locations = $rootPath.DS.'config'.DS.'environment.php')) {
-    $locations = require_once $locations;
-} else {
-    die('Unable to find your environment.php setup file.');
+$locations = $rootPath.DS.'config'.DS.'environment.php';
+if (file_exists($locations) && ($locations = require_once $locations) && count($locations) && $locations !== ['local' => 'INSERT-HOSTNAME', 'production' => 'INSERT-HOSTNAME']) {
+    // They want to use this file!
+    $location = new \Thms\Config\Environment($locations);
+    $location = $location->which(gethostname());
+    if (empty($location)) {
+        die("There is an error in your environment.php file. Most likely the hostname isn't found. Note: This server's hostname is: " . gethostname());
+    }
+    $file = ".env.{$location}";
+}
+
+/* 
+ * Tries to load the environment
+ */
+try {
+    $env = new \Dotenv\Dotenv($rootPath, $file);
+    $env->load();
+    $env->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'WP_HOME', 'WP_SITEURL']);
+} catch (\Exception $e) {
+    die("Error in autoload.php around line 29: " . $e->getMessage());
 }
 
 /*
- * Define environment file
+ * Now we can load in the appropriate config for the specified environment
  */
-$location = new \Thms\Config\Environment($locations);
-$location = $location->which(gethostname());
-$file = empty($location) ? '.env' : ".env.{$location}";
+$location = empty($location) ? getenv('APP_ENV') : $location;
+if (empty($location)) {
 
-/*
- * Load environment
- */
-$env = new \Dotenv\Dotenv($rootPath, $file);
-$env->load();
-$env->required(['DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST', 'WP_HOME', 'WP_SITEURL']);
-
-/*
- * Load environment configuration
- */
-// If .env file selected, default its location to local configuration.
-$location = ('.env' === $file) ? 'local' : $location;
-if (file_exists($config = $rootPath.DS.'config'.DS.'environments'.DS.$location.'.php')) {
-    require_once $config;
+    // If $location is still empty then it's likely they didnt set the APP_ENV
+    die("The environment variable APP_ENV could not be found");
 }
 
 /*
- * Include shared configuration
+ * If the file doesn't load then let them know which file.
+ */
+if (!file_exists($config = $rootPath.DS.'config'.DS.'environments'.DS.$location.'.php')) {
+    die("Failed tryig to load the file: " . $config);
+}
+require_once $config;
+
+/*
+ * Optionally load in a shared config file
  */
 if (file_exists($shared = $rootPath.DS.'config'.DS.'shared.php')) {
     require_once $shared;
 }
+
 
 /*----------------------------------------------------*/
 // Error handling
@@ -69,5 +81,5 @@ if (defined('THEMOSIS_ERROR') && THEMOSIS_ERROR) {
 /*----------------------------------------------------*/
 define('THEMOSIS_STORAGE', $rootPath.DS.'storage');
 define('CONTENT_DIR', 'content');
-define('WP_CONTENT_DIR', $webrootPath.DS.CONTENT_DIR);
+define('WP_CONTENT_DIR', $rootPath.DS.'htdocs'.DS.CONTENT_DIR);
 define('WP_CONTENT_URL', WP_HOME.'/'.CONTENT_DIR);


### PR DESCRIPTION
Okay so here's how it works.

Basically, if the developer either deletes, returns false, returns an empty array, or doesn't edit the environments.php file, then it will attempt to load in .env

Otherwise If they edit the environments.php file with data then it means they intend to use it. In that case it will check they set the hostname correctly, and load in .env.local.php or whatever they set.

The reason this is needed is if you want to use an environment variable such as APP_ENV=local or APP_ENV=production then it can be done in the .env file (currently it would assume local). It's also backwards compatible here.

This approach forces the developer to avoid adding their environment variables to version control, which is a common [mistake among new developers](https://github.com/search?q=removes+env+file&type=Commits&utf8=%E2%9C%93). 

Let me know what you think!

