### PR TITLE
add muplugin installer path in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
   "extra":{
     "installer-paths": {
       "htdocs/content/plugins/{$name}/": ["type:wordpress-plugin"],
+      "htdocs/content/mu-plugins/{$name}/": ["type:wordpress-muplugin"],
       "htdocs/content/themes/{$name}/": ["type:wordpress-theme"]
     },
     "wordpress-install-dir": {


### PR DESCRIPTION
Add installer path in composer for WordPress must-use plugins.  
Something we have in all our sites.