### PR TITLE
comment out salts constants

### DIFF
--- a/config/wordpress.php
+++ b/config/wordpress.php
@@ -17,16 +17,18 @@
 |--------------------------------------------------------------------------
 |
 | @link https://api.wordpress.org/secret-key/1.1/salt/
+| Alternatively use the wp-cli command `wp config shuffle-salts`
+| to add salts to wp-config.php
 |
 */
-define('AUTH_KEY', 'put your unique phrase here');
-define('SECURE_AUTH_KEY', 'put your unique phrase here');
-define('LOGGED_IN_KEY', 'put your unique phrase here');
-define('NONCE_KEY', 'put your unique phrase here');
-define('AUTH_SALT', 'put your unique phrase here');
-define('SECURE_AUTH_SALT', 'put your unique phrase here');
-define('LOGGED_IN_SALT', 'put your unique phrase here');
-define('NONCE_SALT', 'put your unique phrase here');
+// define('AUTH_KEY', 'put your unique phrase here');
+// define('SECURE_AUTH_KEY', 'put your unique phrase here');
+// define('LOGGED_IN_KEY', 'put your unique phrase here');
+// define('NONCE_KEY', 'put your unique phrase here');
+// define('AUTH_SALT', 'put your unique phrase here');
+// define('SECURE_AUTH_SALT', 'put your unique phrase here');
+// define('LOGGED_IN_SALT', 'put your unique phrase here');
+// define('NONCE_SALT', 'put your unique phrase here');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
I have a system that auto deploys sites to a sever and configures various things automatically. Without these commented out running `wp config shuffle-salts` will cause a fatal error (as the constants become defined twice).

However, ideally this section should be removed as this file is in version control and security details/authentication credentials shouldn't be added. 

