### PR TITLE
Handle post-autoload-dump event on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,10 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "scripts": {
+    "post-autoload-dump": [
+      "Themosis\\Core\\ComposerScripts::postAutoloadDump",
+      "@php console package:discover --ansi"
+    ],
     "post-root-package-install": [
       "@php -r \"file_exists('.env') || copy('.env.sample', '.env');\""
     ],


### PR DESCRIPTION
### Why

See https://github.com/themosis/framework/pull/694
To use the new ability to discover packages and automatically get packages' services providers and aliases, we need to trigger `ComposerScripts::postAutoloadDump` method and `package:discover` command after composer's script event `post-autoload-dump`.

### How

Simply handle `post-autoload-dump` event on composer.json by adding those lines under `scripts` node : 
```
   "post-autoload-dump": [
      "Themosis\\Core\\ComposerScripts::postAutoloadDump",
      "@php console package:discover --ansi"
    ],
```

resolve #305 