### PR TITLE
Add Crypt alias on config/app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -180,6 +180,7 @@ return [
         'Cache' => Illuminate\Support\Facades\Cache::class,
         'Config' => Illuminate\Support\Facades\Config::class,
         'Console' => Themosis\Core\Support\Facades\Console::class,
+        'Crypt' => Illuminate\Support\Facades\Crypt::class,
         'DB' => Illuminate\Support\Facades\DB::class,
         'Eloquent' => Illuminate\Database\Eloquent\Model::class,
         'Field' => Themosis\Support\Facades\Field::class,


### PR DESCRIPTION
### Why

On `themosis/framework` branch `2.0`, we have now have two new helpers to encrypt en decrypt data : `encrypt()` and `decrypt()`.
We could set the `Crypt` alias by default on `config/app.php`.

### How

On `config/app.php`, add this line on `aliases` : 
`'Crypt' => Illuminate\Support\Facades\Crypt::class,`

resolve #309 