### PR TITLE
Make sure the $app variable on wp-config.php is an instance of Themosis\Core\Application

### DIFF
--- a/htdocs/wp-config.php
+++ b/htdocs/wp-config.php
@@ -21,6 +21,9 @@ if (file_exists($autoload = THEMOSIS_ROOT.'/vendor/autoload.php')) {
 }
 
 $app = require_once __DIR__.'/../bootstrap/app.php';
+if ($app === true) {
+    $app = app();
+}
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
### Why

On this issue : themosis/framework#646, i'm working on making Wordpress loading on a custom command.
The `wp-config.php` file will be called on a CLI context, the `bootstrap\app.php` file will be already required.

The `$app` variable on the `wp-config.php` file will be `true` instead of being an instance of `Themosis\Core\Application`.

### How

By checking if the `$app` is strictly equal to true, we can re-instanciate the `Themosis\Core\Application` with the `app()` helper :
```
$app = require_once __DIR__.'/../bootstrap/app.php';
if ($app === true) {
    $app = app();
}
```

### More

I feel like there is another cleaner way to do this...

resolve #312 