### PR TITLE
Update wordpress-core-installer to 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   "require": {
     "php": ">=7.1.0",
     "johnpbloch/wordpress-core": "^5.1.0",
-    "johnpbloch/wordpress-core-installer": "^1.0",
+    "johnpbloch/wordpress-core-installer": "^2.0",
     "themosis/framework": "^2.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
In order to create a new Themosis project using Composer v2 the johnpbloch/wordpress-core-installer needs to be ^2.0