### PR TITLE
Change master to main in themosis/framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "php": "^7.3|^8.0",
     "johnpbloch/wordpress-core": "^5.7.0",
     "johnpbloch/wordpress-core-installer": "^2.0",
-    "themosis/framework": "dev-master",
+    "themosis/framework": "dev-main",
     "fideloper/proxy": "^4.4",
     "fruitcake/laravel-cors": "^2.0"
   },


### PR DESCRIPTION
Trying to set up themosis in PHP 8 using the main branch gives an error: 

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires themosis/framework dev-master, found themosis/framework[dev-feature/salt-keys, dev-dependabot/npm_and_yarn/color-string-1.6.0, dev-dependabot/npm_and_yarn/follow-redirects-1.14.7, dev-dependabot/npm_and_yarn/url-parse-1.5.3, dev-feature/laravel-6, dev-feature/auth, dev-experiment, dev-main, dev-feature/623-dropins, dev-feature/639-queue, dev-feature/753-twig, dev-feature/758-broadcasting, dev-develop, v0.8-beta, ..., 0.9.9, 1.0.0, ..., 1.3.x-dev, 2.0-beta1, ..., 2.1.0] but it does not match the constraint. Perhaps dev-master was renamed to dev-main?
```