### PR TITLE
Log deprecations notices

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_DEBUG=false
+APP_DEBUG=true
 APP_KEY=
 APP_TD=themosis
 
@@ -20,6 +20,10 @@ DATABASE_USER=root
 DATABASE_PASSWORD=root
 DATABASE_HOST=localhost
 DATABASE_PREFIX=th_
+
+LOG_CHANNEL=stack
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
 
 MAIL_HOST=your-smtp-host
 MAIL_USERNAME=null

--- a/.env.sample
+++ b/.env.sample
@@ -22,7 +22,6 @@ DATABASE_HOST=localhost
 DATABASE_PREFIX=th_
 
 LOG_CHANNEL=stack
-LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 MAIL_HOST=your-smtp-host

--- a/config/logging.php
+++ b/config/logging.php
@@ -63,6 +63,11 @@ return [
             'days' => 7,
         ],
 
+        'deprecations' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/themosis-deprecations.log'),
+        ],
+
         'slack' => [
             'driver' => 'slack',
             'url' => env('LOG_SLACK_WEBHOOK_URL'),

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,9 @@
 <?php
 
+use Monolog\Handler\NullHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Handler\SyslogUdpHandler;
+
 return [
 
     /*
@@ -13,6 +17,18 @@ return [
     |
     */
     'default' => env('LOG_CHANNEL', 'stack'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Deprecations Log Channel
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the log channel that should be used to log warnings
+    | regarding deprecated PHP and library features. This allows you to get
+    | your application ready for upcoming major versions of dependencies.
+    |
+    */
+    'deprecations' => env('LOG_DEPRECATIONS_CHANNEL', 'null'),
 
     /*
     |--------------------------------------------------------------------------
@@ -55,14 +71,43 @@ return [
             'level' => 'critical',
         ],
 
+        'papertrail' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => SyslogUdpHandler::class,
+            'handler_with' => [
+                'host' => env('PAPERTRAIL_URL'),
+                'port' => env('PAPERTRAIL_PORT'),
+            ],
+        ],
+
+        'stderr' => [
+            'driver' => 'monolog',
+            'level' => env('LOG_LEVEL', 'debug'),
+            'handler' => StreamHandler::class,
+            'formatter' => env('LOG_STDERR_FORMATTER'),
+            'with' => [
+                'stream' => 'php://stderr',
+            ],
+        ],
+
         'syslog' => [
             'driver' => 'syslog',
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
         ],
 
         'errorlog' => [
             'driver' => 'errorlog',
-            'level' => 'debug',
+            'level' => env('LOG_LEVEL', 'debug'),
+        ],
+
+        'null' => [
+            'driver' => 'monolog',
+            'handler' => NullHandler::class,
+        ],
+
+        'emergency' => [
+            'path' => storage_path('logs/themosis.log'),
         ],
     ],
 ];


### PR DESCRIPTION
Update logging configuration to support PHP and user deprecations. This PR also brings a default `deprecations` channel that logs all deprecations to a separate `themosis-deprecations.log` file.